### PR TITLE
Skip tests on CRAN

### DIFF
--- a/tests/testthat/test-stan-calc_unique_pmfs.R
+++ b/tests/testthat/test-stan-calc_unique_pmfs.R
@@ -1,15 +1,15 @@
 context("id_stancode.idbrms_convolution")
 
-if (!testthat:::on_cran()) {
-  files <- c("discretised_lognormal_pmf.stan",
-             "calc_pmf.stan",
-             "calc_unique_pmfs.stan")
-  suppressMessages(
-    expose_idbrms_stan_fns(
-      files, dir =  system.file("stan/functions", package = "idbrms")
-      )
-    )
-}
+skip_on_cran()
+
+files <- c("discretised_lognormal_pmf.stan",
+           "calc_pmf.stan",
+           "calc_unique_pmfs.stan")
+suppressMessages(
+  expose_idbrms_stan_fns(
+    files, dir =  system.file("stan/functions", package = "idbrms")
+  )
+)
 
 
 test_that("calc_unique_pmfs: Successfully calculates a singe PMF", {


### PR DESCRIPTION
fix #6

This is the recommended way to skip tests on CRAN. It is discouraged to use `testthat:::on_cran()` directly (this is why it's not exported).

Please let me know if I misunderstood something!

I did not test locally because I have a strange error with the parallel compilation of stan functions. I'm quite confident it's unrelated though.